### PR TITLE
Added compatibility with GNU utils 2.00

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -94,14 +94,9 @@ UnitProvider.prototype = {
 			}
 
             try {
-				let [success, out, err, error] = GLib.spawn_sync(null, ["units", one, two], null, 4, null)
+				let [success, out, err, error] = GLib.spawn_sync(null, ["units", "-t", one, two], null, 4, null)
 				if(error == 0) {
-					result = out.toString().split('\n')[0];
-					if(result.indexOf("*") == 1) {
-						result = result.substring(3);
-					} else {
-						result = result.substring(1);
-					}
+					result = out.toString();
 					this._lastResult = result;
 					this.searchSystem.pushResults(this,
 							[{'expr': expr, 'result': result}]);


### PR DESCRIPTION
Using this extension on Archlinux with GNU units 2.00 displayed "urrency exchange rates from 2012-06-06" (a new message displayed by units 2.00) instead of the actual result of the conversion.

I modified the way units is launched, now using "-t" option to only get the actual conversion result and removed the now unnecessary parsing of said result.

I tested the modification with units 2.00 (current version in Arch), units 1.88 (current version in Debian testing) and 1.87 (Debian stable uses 1.87) and it worked as expected.
